### PR TITLE
Avoid throwing from destructor

### DIFF
--- a/lang/c++/impl/DataFile.cc
+++ b/lang/c++/impl/DataFile.cc
@@ -122,7 +122,9 @@ void DataFileWriterBase::init(const ValidSchema &schema, size_t syncInterval, co
 DataFileWriterBase::~DataFileWriterBase()
 {
     if (stream_.get()) {
-        close();
+        try {
+            close();
+        } catch(...) {}
     }
 }
 


### PR DESCRIPTION
`close()` can throw.

 ```
2020.02.05 19:26:52.443294 [ 72 ] {47a12579-5a5a-48b5-9422-a4d9c1209e69} <Error> executeQuery: Code: 24, e.displayText() = DB::Exception: Cannot write to ostream at offset 374668313: While executing AvroRowOutputF
ormat (version 20.2.1.1) (from 192.168.117.128:58066) (in query: select toString(channel_id) as channel_id, event_time  from readings_data  format Avro  ), Stack trace (when copying this message, always include th
e lines below):

0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x95618dc in /usr/bin/clickhouse
1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x46bae79 in /usr/bin/clickhouse
2. DB::WriteBufferFromOStream::nextImpl() (.cold) @ 0x45e1f5a in /usr/bin/clickhouse
3. DB::WriteBufferFromHTTPServerResponse::nextImpl() @ 0x90b1e8e in /usr/bin/clickhouse
4. DB::OutputStreamWriteBufferAdapter::flush() @ 0x89301ed in /usr/bin/clickhouse
5. avro::copy(avro::InputStream&, avro::OutputStream&) @ 0x992236a in /usr/bin/clickhouse
6. avro::DataFileWriterBase::sync() @ 0x991c2ac in /usr/bin/clickhouse
7. DB::AvroRowOutputFormat::write(std::__1::vector<COW<DB::IColumn>::immutable_ptr<DB::IColumn>, std::__1::allocator<COW<DB::IColumn>::immutable_ptr<DB::IColumn> > > const&, unsigned long) @ 0x8926c03 in /usr/bin/
clickhouse
8. DB::IRowOutputFormat::consume(DB::Chunk) @ 0x8eb895a in /usr/bin/clickhouse
9. DB::IOutputFormat::work() @ 0x88f742d in /usr/bin/clickhouse
10. std::__1::__function::__func<DB::PipelineExecutor::addJob(DB::PipelineExecutor::ExecutionState*)::'lambda'(), std::__1::allocator<DB::PipelineExecutor::addJob(DB::PipelineExecutor::ExecutionState*)::'lambda'()
>, void ()>::operator()() @ 0x88e70cd in /usr/bin/clickhouse
11. DB::PipelineExecutor::executeSingleThread(unsigned long, unsigned long) @ 0x88e9ca7 in /usr/bin/clickhouse
12. ThreadFromGlobalPool::ThreadFromGlobalPool<DB::PipelineExecutor::executeImpl(unsigned long)::'lambda0'()>(DB::PipelineExecutor::executeImpl(unsigned long)::'lambda0'()&&)::'lambda'()::operator()() const @ 0x88
eaaf2 in /usr/bin/clickhouse
13. ThreadPoolImpl<std::__1::thread>::worker(std::__1::__list_iterator<std::__1::thread, void*>) @ 0x46f1c57 in /usr/bin/clickhouse
14. void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void ThreadPoolImpl<std::__1::thread>::scheduleImpl<void>(s
td::__1::function<void ()>, int, std::__1::optional<unsigned long>)::'lambda1'()> >(void*) @ 0x46f020f in /usr/bin/clickhouse
15. start_thread @ 0x76db in /lib/x86_64-linux-gnu/libpthread-2.27.so
16. clone @ 0x12188f in /lib/x86_64-linux-gnu/libc-2.27.so

2020.02.05 19:26:52.444082 [ 47 ] {} <Fatal> BaseDaemon: (version 20.2.1.1) (from thread 72) Terminate called for uncaught exception:
Code: 24, e.displayText() = DB::Exception: Cannot write to ostream at offset 374665547, Stack trace (when copying this message, always include the lines below):

0. Poco::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x95618dc in /usr/bin/clickhouse
1. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int) @ 0x46bae79 in /usr/bin/clickhouse
2. DB::WriteBufferFromOStream::nextImpl() (.cold) @ 0x45e1f5a in /usr/bin/clickhouse
3. DB::WriteBufferFromHTTPServerResponse::nextImpl() @ 0x90b1e8e in /usr/bin/clickhouse
4. DB::OutputStreamWriteBufferAdapter::flush() @ 0x89301ed in /usr/bin/clickhouse
5. avro::DataFileWriterBase::sync() @ 0x991c29b in /usr/bin/clickhouse
6. avro::DataFileWriterBase::~DataFileWriterBase() @ 0x991cc65 in /usr/bin/clickhouse
7. DB::AvroRowOutputFormat::~AvroRowOutputFormat() @ 0x892c754 in /
```